### PR TITLE
Settings for Talk

### DIFF
--- a/server_configuration.md
+++ b/server_configuration.md
@@ -243,6 +243,28 @@ Enter password: [lineschool]
 > COMMIT;
 ```
 
+
+```
+> CREATE DATABASE IF NOT EXISTS talk_info DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
+
+> USE talk_info;
+> create table talks (
+    talk_id bigint(13) NOT NULL,
+    sender_id varchar(255) COLLATE utf8mb4_bin NOT NULL,
+    send_room_num bigint(13) NOT NULL,
+    text varchar(255) COLLATE utf8mb4_bin NOT NULL,
+    num_read bigint(13) NOT NULL DEFAULT 0,
+    created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at timestamp NOT NULL DEFAULT '2018-01-01 00:00:00'
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+
+> ALTER TABLE talk_info.talks ADD PRIMARY KEY (talk_id);
+> ALTER TABLE talk_info.talks MODIFY talk_id bigint(13) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=0;
+
+> GRANT ALL PRIVILEGES ON talk_info.* TO dbuser@'localhost' IDENTIFIED BY 'lineschool'; // 重要
+> COMMIT;
+```
+
 ### メモ
 ```
 > CREATE DATABASE IF NOT EXISTS client_info DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;

--- a/src/main/kotlin/com/example/apiSample/controller/TalkController.kt
+++ b/src/main/kotlin/com/example/apiSample/controller/TalkController.kt
@@ -1,0 +1,44 @@
+package com.example.apiSample.controller
+
+import com.example.apiSample.model.Talk
+import com.example.apiSample.service.TalkService
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.*
+
+
+@RestController
+class TalkController(private val talkService: TalkService) {
+    @PostMapping(
+            value = ["/talk/create/{senderId}/{roomId}/{text}"],
+            produces = [MediaType.APPLICATION_JSON_UTF8_VALUE]
+    )
+    fun addTalk(@PathVariable("senderId") senderId: String, @PathVariable("roomId") roomId: Long, @PathVariable("text") text: String): Unit {
+        talkService.addTalk(senderId, roomId, text)
+    }
+
+    @GetMapping(
+            value = ["/talk"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun getAllTalks(): ArrayList<Talk> {
+        return talkService.getAllTalks()
+    }
+
+    @GetMapping(
+            value = ["/talk/{roomId}/{sinceTalkId}"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun getTalk(@PathVariable("roomId") roomId: Long, @PathVariable("sinceTalkId") sinceTalkId: Long): ArrayList<Talk> {
+        return talkService.getTalk(roomId, sinceTalkId)
+    }
+
+    @DeleteMapping(
+            value = ["/talk/delete/before/{talkId}"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun deleteTalkBeforeId(@PathVariable("talkId") talkId: Long): ArrayList<Talk> {
+        val deleteList: ArrayList<Talk> = talkService.getTalkBeforeId(talkId)
+        talkService.deleteTalkBeforeId(talkId)
+        return deleteList // 削除したデータのリストを返す
+    }
+}

--- a/src/main/kotlin/com/example/apiSample/controller/UserController.kt
+++ b/src/main/kotlin/com/example/apiSample/controller/UserController.kt
@@ -1,9 +1,11 @@
 package com.example.apiSample.controller
 
+import com.example.apiSample.model.Talk
 import com.example.apiSample.model.UserProfile
 import com.example.apiSample.service.UserProfileService
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
+import java.sql.Timestamp
 
 /*
 data class UserListResponse(
@@ -15,6 +17,13 @@ data class PostSearchRequest(
         val search_str: String
 )
 */
+data class TalkResponse(
+        var text: String,
+        var created_at: Timestamp
+)
+data class GetTalkRequest(
+        val requested_time: Timestamp
+)
 
 @RestController
 class UserController(private val userProfileService: UserProfileService) {
@@ -94,5 +103,28 @@ class UserController(private val userProfileService: UserProfileService) {
         return deleteList // 削除したデータのリストを返す
     }
 
+    /* --- talk operation --- */
+    @PostMapping(
+            value = ["/talk/create/{sender_id}/{send_room_num}/{text}"],
+            produces = [MediaType.APPLICATION_JSON_UTF8_VALUE]
+    )
+    fun addTalk(@PathVariable("sender_id") sender_id: String, @PathVariable("send_room_num") send_room_num: Long, @PathVariable("text") text: String): Unit {
+        userProfileService.addTalk(sender_id, send_room_num, text)
+    }
 
+    @GetMapping(
+            value = ["/talk"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun getAllTalks(): ArrayList<Talk> {
+        return userProfileService.getAllTalks()
+    }
+
+    @GetMapping(
+            value = ["/talk/{receive_room_num}/{since_talk_id}"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun getTalk(@PathVariable("receive_room_num") receive_room_num: Long, @PathVariable("since_talk_id") since_talk_id: Long): ArrayList<Talk> {
+        return userProfileService.getTalk(receive_room_num, since_talk_id)
+    }
 }

--- a/src/main/kotlin/com/example/apiSample/controller/UserController.kt
+++ b/src/main/kotlin/com/example/apiSample/controller/UserController.kt
@@ -5,7 +5,6 @@ import com.example.apiSample.model.UserProfile
 import com.example.apiSample.service.UserProfileService
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.*
-import java.sql.Timestamp
 
 /*
 data class UserListResponse(
@@ -17,13 +16,7 @@ data class PostSearchRequest(
         val search_str: String
 )
 */
-data class TalkResponse(
-        var text: String,
-        var created_at: Timestamp
-)
-data class GetTalkRequest(
-        val requested_time: Timestamp
-)
+
 
 @RestController
 class UserController(private val userProfileService: UserProfileService) {

--- a/src/main/kotlin/com/example/apiSample/controller/UserController.kt
+++ b/src/main/kotlin/com/example/apiSample/controller/UserController.kt
@@ -1,6 +1,5 @@
 package com.example.apiSample.controller
 
-import com.example.apiSample.model.Talk
 import com.example.apiSample.model.UserProfile
 import com.example.apiSample.service.UserProfileService
 import org.springframework.http.MediaType
@@ -94,30 +93,5 @@ class UserController(private val userProfileService: UserProfileService) {
         val deleteList: UserProfile = userProfileService.getUserById(id)
         userProfileService.deleteProfile(id)
         return deleteList // 削除したデータのリストを返す
-    }
-
-    /* --- talk operation --- */
-    @PostMapping(
-            value = ["/talk/create/{sender_id}/{send_room_num}/{text}"],
-            produces = [MediaType.APPLICATION_JSON_UTF8_VALUE]
-    )
-    fun addTalk(@PathVariable("sender_id") sender_id: String, @PathVariable("send_room_num") send_room_num: Long, @PathVariable("text") text: String): Unit {
-        userProfileService.addTalk(sender_id, send_room_num, text)
-    }
-
-    @GetMapping(
-            value = ["/talk"],
-            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
-    )
-    fun getAllTalks(): ArrayList<Talk> {
-        return userProfileService.getAllTalks()
-    }
-
-    @GetMapping(
-            value = ["/talk/{receive_room_num}/{since_talk_id}"],
-            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
-    )
-    fun getTalk(@PathVariable("receive_room_num") receive_room_num: Long, @PathVariable("since_talk_id") since_talk_id: Long): ArrayList<Talk> {
-        return userProfileService.getTalk(receive_room_num, since_talk_id)
     }
 }

--- a/src/main/kotlin/com/example/apiSample/mapper/TalkMapper.kt
+++ b/src/main/kotlin/com/example/apiSample/mapper/TalkMapper.kt
@@ -1,0 +1,46 @@
+package com.example.apiSample.mapper
+
+import com.example.apiSample.model.Talk
+import org.apache.ibatis.annotations.Delete
+import org.apache.ibatis.annotations.Insert
+import org.apache.ibatis.annotations.Mapper
+import org.apache.ibatis.annotations.Select
+
+@Mapper
+interface TalkMapper {
+    @Insert(
+        """
+        INSERT INTO talk_info.talks (sender_id, send_room_num, text)
+        VALUES (#{senderId}, #{roomId}, #{text})
+        """
+    )
+    fun addTalk(senderId: String, roomId: Long, text: String): Unit
+
+    @Select(
+        """
+        SELECT * from talk_info.talks
+        """
+    )
+    fun getAllTalks(): ArrayList<Talk>
+
+    @Select(
+        """
+        SELECT * from talk_info.talks WHERE send_room_num=#{roomId} AND talk_id>#{sinceTalkId}
+        """
+    )
+    fun getTalk(roomId: Long, sinceTalkId: Long): ArrayList<Talk>
+
+    @Select(
+        """
+        SELECT * from talk_info.talks WHERE talk_id<=#{talkId}
+        """
+    )
+    fun getTalkBeforeId(talkId: Long): ArrayList<Talk>
+
+    @Delete(
+        """
+        DELETE from talk_info.talks WHERE talk_id<=#{talkId}
+        """
+    )
+    fun deleteTalkBeforeId(talkId: Long)
+}

--- a/src/main/kotlin/com/example/apiSample/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/example/apiSample/mapper/UserMapper.kt
@@ -1,10 +1,12 @@
 package com.example.apiSample.mapper
 
+import com.example.apiSample.model.Talk
 import com.example.apiSample.model.UserProfile
 import org.apache.ibatis.annotations.Delete
 import org.apache.ibatis.annotations.Insert
 import org.apache.ibatis.annotations.Mapper
 import org.apache.ibatis.annotations.Select
+import java.sql.Timestamp
 
 @Mapper
 interface UserMapper {
@@ -63,4 +65,28 @@ interface UserMapper {
         """
     )
     fun deleteProfile(id: String): Unit
+
+
+    /* --- talk operation ---*/
+    @Insert(
+        """
+        INSERT INTO talk_info.talks (sender_id, send_room_num, text)
+        VALUES (#{sender_id}, #{send_room_num}, #{text})
+        """
+    )
+    fun addTalk(sender_id: String, send_room_num: Long, text: String): Unit
+
+    @Select(
+        """
+        SELECT * from talk_info.talks
+        """
+    )
+    fun getAllTalks(): ArrayList<Talk>
+
+    @Select(
+        """
+        SELECT * from talk_info.talks WHERE send_room_num=#{receive_room_num} AND talk_id>#{since_talk_id}
+        """
+    )
+    fun getTalk(receive_room_num: Long, since_talk_id: Long): ArrayList<Talk>
 }

--- a/src/main/kotlin/com/example/apiSample/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/example/apiSample/mapper/UserMapper.kt
@@ -1,6 +1,5 @@
 package com.example.apiSample.mapper
 
-import com.example.apiSample.model.Talk
 import com.example.apiSample.model.UserProfile
 import org.apache.ibatis.annotations.Delete
 import org.apache.ibatis.annotations.Insert
@@ -20,7 +19,7 @@ interface UserMapper {
     // idでユーザを探す（返り値は単体のはず）
     @Select(
         """
-        SELECT id, name, created_at, updated_at FROM client_info.clients WHERE id=#{userId}
+        SELECT * FROM client_info.clients WHERE id=#{userId}
         """
     )
     fun findByUserId(userId: String): UserProfile
@@ -64,28 +63,4 @@ interface UserMapper {
         """
     )
     fun deleteProfile(id: String): Unit
-
-
-    /* --- talk operation ---*/
-    @Insert(
-        """
-        INSERT INTO talk_info.talks (sender_id, send_room_num, text)
-        VALUES (#{sender_id}, #{send_room_num}, #{text})
-        """
-    )
-    fun addTalk(sender_id: String, send_room_num: Long, text: String): Unit
-
-    @Select(
-        """
-        SELECT * from talk_info.talks
-        """
-    )
-    fun getAllTalks(): ArrayList<Talk>
-
-    @Select(
-        """
-        SELECT * from talk_info.talks WHERE send_room_num=#{receive_room_num} AND talk_id>#{since_talk_id}
-        """
-    )
-    fun getTalk(receive_room_num: Long, since_talk_id: Long): ArrayList<Talk>
 }

--- a/src/main/kotlin/com/example/apiSample/mapper/UserMapper.kt
+++ b/src/main/kotlin/com/example/apiSample/mapper/UserMapper.kt
@@ -6,7 +6,6 @@ import org.apache.ibatis.annotations.Delete
 import org.apache.ibatis.annotations.Insert
 import org.apache.ibatis.annotations.Mapper
 import org.apache.ibatis.annotations.Select
-import java.sql.Timestamp
 
 @Mapper
 interface UserMapper {

--- a/src/main/kotlin/com/example/apiSample/model/entities.kt
+++ b/src/main/kotlin/com/example/apiSample/model/entities.kt
@@ -6,8 +6,8 @@ import java.sql.Timestamp
 data class UserProfile(
         var id: String,
         var name: String,
-        @get:JsonProperty("created_at") var createdAt: Timestamp,
-        @get:JsonProperty("updated_at") var updatedAt: Timestamp
+        @get:JsonProperty("createdAt") var createdAt: Timestamp,
+        @get:JsonProperty("updatedAt") var updatedAt: Timestamp
 )
 
 /*
@@ -20,11 +20,11 @@ data class UserList(
 */
 
 data class Talk(
-        var talk_id: Long,
-        var sender_id: String,
-        var send_room_num: Long,
+        var talkId: Long,
+        var senderId: String,
+        var roomId: Long,
         var text: String,
-        var num_read: Long,
-        @get:JsonProperty("created_at") var createdAt: Timestamp,
-        @get:JsonProperty("updated_at") var updatedAt: Timestamp
+        var numRead: Long,
+        @get:JsonProperty("createdAt") var createdAt: Timestamp,
+        @get:JsonProperty("updatedAt") var updatedAt: Timestamp
 )

--- a/src/main/kotlin/com/example/apiSample/model/entities.kt
+++ b/src/main/kotlin/com/example/apiSample/model/entities.kt
@@ -20,9 +20,11 @@ data class UserList(
 */
 
 data class Talk(
+        var talk_id: Long,
         var sender_id: String,
-        var recever_id: String,
+        var send_room_num: Long,
         var text: String,
+        var num_read: Long,
         @get:JsonProperty("created_at") var createdAt: Timestamp,
         @get:JsonProperty("updated_at") var updatedAt: Timestamp
 )

--- a/src/main/kotlin/com/example/apiSample/service/TalkService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/TalkService.kt
@@ -1,0 +1,28 @@
+package com.example.apiSample.service
+
+import com.example.apiSample.mapper.TalkMapper
+import com.example.apiSample.model.Talk
+import org.springframework.stereotype.Service
+
+@Service
+class TalkService(private val talkMapper: TalkMapper) {
+    fun addTalk(senderId: String, RoomId: Long, text: String): Unit {
+        talkMapper.addTalk(senderId, RoomId, text)
+    }
+
+    fun getAllTalks(): ArrayList<Talk> {
+        return talkMapper.getAllTalks()
+    }
+
+    fun getTalk(roomId: Long, sinceTalkId: Long): ArrayList<Talk> {
+        return talkMapper.getTalk(roomId, sinceTalkId)
+    }
+
+    fun getTalkBeforeId(talkId: Long): ArrayList<Talk> {
+        return talkMapper.getTalkBeforeId(talkId)
+    }
+
+    fun deleteTalkBeforeId(talkId: Long): Unit {
+        talkMapper.deleteTalkBeforeId(talkId)
+    }
+}

--- a/src/main/kotlin/com/example/apiSample/service/UserProfileService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/UserProfileService.kt
@@ -1,8 +1,10 @@
 package com.example.apiSample.service
 
 import com.example.apiSample.mapper.UserMapper
+import com.example.apiSample.model.Talk
 import com.example.apiSample.model.UserProfile
 import org.springframework.stereotype.Service
+import java.sql.Timestamp
 
 @Service
 class UserProfileService(private val userMapper: UserMapper) {
@@ -41,4 +43,16 @@ class UserProfileService(private val userMapper: UserMapper) {
         userMapper.deleteProfile(id)
     }
 
+    /* --- talk operation --- */
+    fun addTalk(sender_id: String, send_room_num: Long, text: String): Unit {
+        userMapper.addTalk(sender_id, send_room_num, text)
+    }
+
+    fun getAllTalks(): ArrayList<Talk> {
+        return userMapper.getAllTalks()
+    }
+
+    fun getTalk(receive_room_num: Long, since_talk_id: Long): ArrayList<Talk> {
+        return userMapper.getTalk(receive_room_num, since_talk_id)
+    }
 }

--- a/src/main/kotlin/com/example/apiSample/service/UserProfileService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/UserProfileService.kt
@@ -4,7 +4,6 @@ import com.example.apiSample.mapper.UserMapper
 import com.example.apiSample.model.Talk
 import com.example.apiSample.model.UserProfile
 import org.springframework.stereotype.Service
-import java.sql.Timestamp
 
 @Service
 class UserProfileService(private val userMapper: UserMapper) {

--- a/src/main/kotlin/com/example/apiSample/service/UserProfileService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/UserProfileService.kt
@@ -41,17 +41,4 @@ class UserProfileService(private val userMapper: UserMapper) {
     fun deleteProfile(id: String): Unit {
         userMapper.deleteProfile(id)
     }
-
-    /* --- talk operation --- */
-    fun addTalk(sender_id: String, send_room_num: Long, text: String): Unit {
-        userMapper.addTalk(sender_id, send_room_num, text)
-    }
-
-    fun getAllTalks(): ArrayList<Talk> {
-        return userMapper.getAllTalks()
-    }
-
-    fun getTalk(receive_room_num: Long, since_talk_id: Long): ArrayList<Talk> {
-        return userMapper.getTalk(receive_room_num, since_talk_id)
-    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ server:
   port: 80
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/apisample
+    url: jdbc:mysql://localhost:3306/apisample?useUnicode=yes&characterEncoding=UTF-8&connectionCollation=utf8mb4_bin
     username: dbuser
     password: lineschool
+    type: com.zaxxer.hikari.HikariDataSource
+    hikari:
+      connection-init-sql: set names utf8mb4


### PR DESCRIPTION
Added database table and data manipulation methods for talks. #5

トーク用のテーブルのデータ構成は以下．
```
data class Talk(
        var talk_id: Long,
        var sender_id: String,
        var send_room_num: Long,
        var text: String,
        var num_read: Long,
        @get:JsonProperty("created_at") var createdAt: Timestamp,
        @get:JsonProperty("updated_at") var updatedAt: Timestamp
)
```
上から，誰が送ったか，トークのid，どのルームに送るか，送る内容，既読数です．

APIの詳細はあとで追加しますが，簡単には以下．
- すべてのトークを取得する
```
curl -X GET http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/talk
```
- `recieve_room_num`の部屋番号に`since_talk_id`以降のtalk_idがついたトークを取得する
```
curl -X GET http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/talk/{recieve_room_num}/{since_talk_id}
```
- idが`sender_id`のクライアントから`send_room_num`の部屋番号に`text`の文章を送信する
```
curl -X POST http://ec2-52-197-250-179.ap-northeast-1.compute.amazonaws.com/talk/{sender_id}/{send_room_num}/{text}
```