### PR TITLE
fixed parse problem

### DIFF
--- a/src/main/kotlin/com/example/apiSample/mapper/TalkMapper.kt
+++ b/src/main/kotlin/com/example/apiSample/mapper/TalkMapper.kt
@@ -10,7 +10,7 @@ import org.apache.ibatis.annotations.Select
 interface TalkMapper {
     @Insert(
         """
-        INSERT INTO talk_info.talks (sender_id, send_room_num, text)
+        INSERT INTO talk_info.talks (sender_id, room_id, text)
         VALUES (#{senderId}, #{roomId}, #{text})
         """
     )
@@ -25,7 +25,7 @@ interface TalkMapper {
 
     @Select(
         """
-        SELECT * from talk_info.talks WHERE send_room_num=#{roomId} AND talk_id>#{sinceTalkId}
+        SELECT * from talk_info.talks WHERE room_id=#{roomId} AND talk_id>#{sinceTalkId}
         """
     )
     fun getTalk(roomId: Long, sinceTalkId: Long): ArrayList<Talk>

--- a/src/main/kotlin/com/example/apiSample/model/entities.kt
+++ b/src/main/kotlin/com/example/apiSample/model/entities.kt
@@ -6,8 +6,8 @@ import java.sql.Timestamp
 data class UserProfile(
         var id: String,
         var name: String,
-        @get:JsonProperty("createdAt") var createdAt: Timestamp,
-        @get:JsonProperty("updatedAt") var updatedAt: Timestamp
+        @get:JsonProperty("created_at") var createdAt: Timestamp,
+        @get:JsonProperty("updated_at") var updatedAt: Timestamp
 )
 
 /*
@@ -20,11 +20,11 @@ data class UserList(
 */
 
 data class Talk(
-        var talkId: Long,
-        var senderId: String,
-        var roomId: Long,
+        @get:JsonProperty("talk_id") var talkId: Long,
+        @get:JsonProperty("sender_id") var senderId: String,
+        @get:JsonProperty("room_id") var roomId: Long,
         var text: String,
-        var numRead: Long,
-        @get:JsonProperty("createdAt") var createdAt: Timestamp,
-        @get:JsonProperty("updatedAt") var updatedAt: Timestamp
+        @get:JsonProperty("num_read") var numRead: Long,
+        @get:JsonProperty("created_at") var createdAt: Timestamp,
+        @get:JsonProperty("updated_at") var updatedAt: Timestamp
 )


### PR DESCRIPTION
この前，クライアント側で各classの変数名を（camel case）に変更した際に，サーバ側とクライアント側でうまく変数がパースできていない（関連付けられていない）状態になってしまっていました．

これは完全にぼくの勘違いで，
`@get:JsonProperty("hoge")`でサーバ側の変数名を指していないといけなかったんですね．
この過程でdbの変数名はsnake caseにするのが一般的というのも知り，テーブルの変数名もいろいろいじりました．こちらは別途[wiki](https://github.com/line-school2018summer/Tokyo_A_Server/wiki)の方にも追記しておきました．

今までその影響が現れていたのが`created_at`と`updated_at`だけだったので，気づかなかったのですね...．だいぶ時間を溶かしてしまいました...．