### PR TITLE
Avoid deleting default image when update user icon

### DIFF
--- a/src/main/kotlin/com/example/apiSample/controller/ImageController.kt
+++ b/src/main/kotlin/com/example/apiSample/controller/ImageController.kt
@@ -49,6 +49,14 @@ class ImageController(private val imageService: ImageService) {
         imageService.addOrModifyImage(id, rawData)
     }
 
+    @PostMapping(
+            value = ["/image/create/default/{id}"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun addDefaultImage(@PathVariable("id") id: String): Unit {
+        imageService.addDefaultImage(id)
+    }
+
     @PutMapping(
             value = ["/image/modify/{id}"],
             produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]

--- a/src/main/kotlin/com/example/apiSample/service/ImageService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/ImageService.kt
@@ -52,6 +52,10 @@ class ImageService(private val imageMapper: ImageMapper) {
         }
     }
 
+    fun addDefaultImage(id: String): Unit {
+        imageMapper.addImage(id, "default.jpg") // テーブルに記録
+    }
+
     fun deleteImage(id: String): Unit {
         deleteImageFile(id)
         imageMapper.deleteImage(id)

--- a/src/main/kotlin/com/example/apiSample/service/ImageService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/ImageService.kt
@@ -94,15 +94,17 @@ class ImageService(private val imageMapper: ImageMapper) {
 
     fun deleteImageFile(id: String): Unit {
         val url = getImageUrlById(id)?.pathToFile
-        val file = File(basePath + "/" + url)
-        if(file.exists()) {
-            if(file.delete()) {
-                println("***** DELETED FILE: $url *****")
+        if (!url.equals("default.jpg")) { // デフォルト画像の場合は，画像データは残しておく
+            val file = File(basePath + "/" + url)
+            if (file.exists()) {
+                if (file.delete()) {
+                    println("***** DELETED FILE: $url *****")
+                } else {
+                    println("***** FAILED TO DELETE FILE: $url *****")
+                }
             } else {
-                println("***** FAILED TO DELETE FILE: $url *****")
+                println("***** FILE NOT FOUND: $url *****")
             }
-        } else {
-            println("***** FILE NOT FOUND: $url *****")
         }
     }
 }


### PR DESCRIPTION
ユーザアイコンのデフォルトのものとして，`/home/ec2-user/images`以下にある`default.jpg`を設定していたわけですが，それをアップデートするときに，今までのアイコン画像を消してから新しい画像を保存するとしていたため，最初のデフォルトのものから他のに変更するときに`default.jpg`が消えてしまい，他のユーザのアイコンがなくなってしまうようになっていました．
画像へのパスが`default.jpg`であったら，画像の消去はしないように修正しました．

mergeは #28 をmergeしてからで．