### PR TITLE
Add is group parameter

### DIFF
--- a/src/main/kotlin/com/example/apiSample/controller/RoomController.kt
+++ b/src/main/kotlin/com/example/apiSample/controller/RoomController.kt
@@ -33,6 +33,14 @@ class RoomController(private val RoomService: RoomService) {
         RoomService.addRoom(roomId, roomName)
     }
 
+    @PostMapping(
+            value = ["/room/create_group/{room_id}/{room_name}"],
+            produces = [(MediaType.APPLICATION_JSON_UTF8_VALUE)]
+    )
+    fun addRoomAsGroup(@PathVariable("room_id") roomId: String, @PathVariable("room_name") roomName: String): Unit {
+        RoomService.addRoomAsGroup(roomId, roomName)
+    }
+
     // PUTに相当する機能; roomの名前の変更
     @PutMapping(
             value = ["/room/modify/{room_id}/{room_name}"],

--- a/src/main/kotlin/com/example/apiSample/mapper/RoomMapper.kt
+++ b/src/main/kotlin/com/example/apiSample/mapper/RoomMapper.kt
@@ -37,11 +37,11 @@ interface RoomMapper {
     // ルームの情報を追加する
     @Insert(
         """
-        INSERT INTO room_info.rooms (room_id, room_name)
-        VALUES (#{roomId}, #{roomName});
+        INSERT INTO room_info.rooms (room_id, room_name, is_group)
+        VALUES (#{roomId}, #{roomName}, #{isGroup});
         """
     )
-    fun addRoom(roomId: String, roomName: String): Unit
+    fun addRoom(roomId: String, roomName: String, isGroup: Boolean): Unit
 
     // ユーザの情報を削除する
     @Delete(

--- a/src/main/kotlin/com/example/apiSample/model/entities.kt
+++ b/src/main/kotlin/com/example/apiSample/model/entities.kt
@@ -31,7 +31,8 @@ data class Room(
         @get:JsonProperty("room_id") var roomId: String,
         @get:JsonProperty("room_name") var roomName: String,
         @get:JsonProperty("created_at") var createdAt: Timestamp,
-        @get:JsonProperty("updated_at") var updatedAt: Timestamp
+        @get:JsonProperty("updated_at") var updatedAt: Timestamp,
+        @get:JsonProperty("is_group") var isGroup: Boolean
 )
 
 data class RoomMember(

--- a/src/main/kotlin/com/example/apiSample/service/RoomService.kt
+++ b/src/main/kotlin/com/example/apiSample/service/RoomService.kt
@@ -21,7 +21,14 @@ class RoomService(private val RoomMapper: RoomMapper) {
     // ルームの情報を追加する
     fun addRoom(roomId: String, roomName: String): Unit {
         if(getRoomById(roomId) == null) {
-            RoomMapper.addRoom(roomId, roomName)
+            RoomMapper.addRoom(roomId, roomName, false)
+        }
+    }
+
+    // ルームの情報を追加する
+    fun addRoomAsGroup(roomId: String, roomName: String): Unit {
+        if(getRoomById(roomId) == null) {
+            RoomMapper.addRoom(roomId, roomName, true)
         }
     }
 


### PR DESCRIPTION
トークルームがグループか個人チャットかを判断するために`isGroup`パラメータを追加しました。
それに伴って、新規ルーム追加時にもグループと個人チャットのどちらで登録するかを指定できるように、窓口を追加しました。